### PR TITLE
XRT-1830: Decouple transaction IDs and return read data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# v0.14
+
+- Added prepare script to build before being added as a module
+- Passes read response data directly from endpoint read() to Zigbee2MQTT using cls-hooked


### PR DESCRIPTION
Reverted most endpoint functions to original, but extended read() to return data from response through cls-hooked.