### PR TITLE
XRT-1819: Catch namespace error on auto-reads

### DIFF
--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -479,10 +479,12 @@ class Endpoint extends Entity {
 
             if (!options.disableResponse) {
                 this.checkStatus(result.frame.Payload);
-                if (session != null) {
-                    session.set('returnMessage', result)
+                try {
+                    session.set('returnMessage', result);
                     session.set('returnCluster', cluster);
                     session.set('returnAttributes', attributes);
+                } catch (e){
+                    debug.info(`Could not set session storage, assuming not user call`);
                 }
                 return ZclFrameConverter.attributeKeyValue(result.frame);
             } else {

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -484,7 +484,7 @@ class Endpoint extends Entity {
                     session.set('returnCluster', cluster);
                     session.set('returnAttributes', attributes);
                 } catch (e){
-                    debug.info(`Could not set session storage, assuming not user call`);
+                    debug.info(`Could not set session storage, not user call`);
                 }
                 return ZclFrameConverter.attributeKeyValue(result.frame);
             } else {


### PR DESCRIPTION
Zigbee-herdsman now catches an error that is thrown when zigbee2mqtt automatically requests data from a device, for example when it first connects. Since the namespace used by cls-hooked has not been created in these cases, the read() endpoint function gave an error when attempting to set namespace variables.

It cannot be determined whether a namespace is running beforehand, so this change simply catches the error and outputs a message saying what has occurred. This approach is better than throwing the error as before, since we would expect this to happen regularly. An alternative would be to disable all auto-reads, but this will interfere with the zigbee2mqtt front-end, so I would prefer to leave the functionality in for now.